### PR TITLE
fix for this error on linux Mint 20: mysql.connector.errors.Interface…

### DIFF
--- a/arjuna/tpi/dbauto/db.py
+++ b/arjuna/tpi/dbauto/db.py
@@ -91,6 +91,8 @@ class DB:
             host=host,
             user=user,
             password=password,
+            ssl_disabled = True,
+
         )
         return MySQL(db, config)
 


### PR DESCRIPTION
…Error: 2026 (HY000):.. :unsupported protocol

I do not know why this error happens (see at the end), but since I updated from Mint 19 to 20 this happens.

I have recreated the venv several times but it did not help.
Strange part is with my test script in the same venv it works without disabling SSL

    import mysql.connector
    server =
    db =
    table =
    user =
    password =
    mydb = mysql.connector.connect(
      host=server,
      user=user,
      password=password,
    )
    mycursor = mydb.cursor()
    query = f'select * from {db}.{table};'
    mycursor.execute(query)
    for x in mycursor:
        print(x)


_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <mysql.connector.connection_cext.CMySQLConnection object at 0x7f1e5c8c30a0>

    def _open_connection(self):
        charset_name = CharacterSet.get_info(self._charset_id)[0]
        self._cmysql = _mysql_connector.MySQL(  # pylint: disable=E1101,I1101
            buffered=self._buffered,
            raw=self._raw,
            charset_name=charset_name,
            connection_timeout=(self._connection_timeout or 0),
            use_unicode=self._use_unicode,
            auth_plugin=self._auth_plugin)
    
        if not self.isset_client_flag(ClientFlag.CONNECT_ARGS):
            self._conn_attrs = {}
        cnx_kwargs = {
            'host': self._host,
            'user': self._user,
            'password': self._password,
            'database': self._database,
            'port': self._port,
            'client_flags': self._client_flags,
            'unix_socket': self._unix_socket,
            'compress': self.isset_client_flag(ClientFlag.COMPRESS),
            'ssl_disabled': True,
            "conn_attrs": self._conn_attrs
        }
    
        tls_versions = self._ssl.get('tls_versions')
        if tls_versions is not None:
            tls_versions.sort(reverse=True)
            tls_versions = ",".join(tls_versions)
        if self._ssl.get('tls_ciphersuites') is not None:
            ssl_ciphersuites = self._ssl.get('tls_ciphersuites')[0]
            tls_ciphersuites = self._ssl.get('tls_ciphersuites')[1]
        else:
            ssl_ciphersuites = None
            tls_ciphersuites = None
        if tls_versions is not None and "TLSv1.3" in tls_versions and \
           not tls_ciphersuites:
            tls_ciphersuites = "TLS_AES_256_GCM_SHA384"
        if not self._ssl_disabled:
            cnx_kwargs.update({
                'ssl_ca': self._ssl.get('ca'),
                'ssl_cert': self._ssl.get('cert'),
                'ssl_key': self._ssl.get('key'),
                'ssl_cipher_suites': ssl_ciphersuites,
                'tls_versions': tls_versions,
                'tls_cipher_suites': tls_ciphersuites,
                'ssl_verify_cert': self._ssl.get('verify_cert') or False,
                'ssl_verify_identity':
                    self._ssl.get('verify_identity') or False,
                'ssl_disabled': self._ssl_disabled
            })
    
        try:
            self._cmysql.connect(**cnx_kwargs)
        except MySQLInterfaceError as exc:
>           raise errors.get_mysql_exception(msg=exc.msg, errno=exc.errno,
                                             sqlstate=exc.sqlstate)
E           mysql.connector.errors.InterfaceError: 2026 (HY000): SSL connection error: error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol

../venv/lib/python3.8/site-packages/mysql/connector/connection_cext.py:218: InterfaceError