### PR TITLE
selenium library upgrade to 4.14.0 - proxy changes

### DIFF
--- a/arjuna/interact/gui/auto/automator/drivercaps.py
+++ b/arjuna/interact/gui/auto/automator/drivercaps.py
@@ -53,7 +53,7 @@ class DriverCapabilities:
     }
 
     # Selenium
-    UNEXPECTED_ALERT_BEHAVIOUR = "unexpectedAlertBehaviour" # accept,dismiss,ignore
+    # UNEXPECTED_ALERT_BEHAVIOUR = "unexpectedAlertBehaviour" # accept,dismiss,ignore
     UNHANDLED_PROMPT_BEHAVIOUR = "unhandledPromptBehavior" # accept,dismiss,ignore
     ELEMENT_SCROLL_BEHAVIOR = "elementScrollBehavior" #???
     AUTOMATION_NAME = "automationName"
@@ -157,7 +157,7 @@ class DriverCapabilities:
                 self.__out_dict["arjuna_options"][k] = v
 
     def __process(self, dict_from_requester):
-        self.__out_dict["driverCapabilities"][self.UNEXPECTED_ALERT_BEHAVIOUR] = "dismiss"
+        # self.__out_dict["driverCapabilities"][self.UNEXPECTED_ALERT_BEHAVIOUR] = "dismiss"
         self.__out_dict["driverCapabilities"][self.UNHANDLED_PROMPT_BEHAVIOUR] = "dismiss"
         if not dict_from_requester: return
         if "browserArgs" in dict_from_requester and dict_from_requester["browserArgs"]:

--- a/arjuna/interact/gui/dispatcher/selenium/browser_launcher.py
+++ b/arjuna/interact/gui/dispatcher/selenium/browser_launcher.py
@@ -19,6 +19,8 @@
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.proxy import *
 
+from arjuna import *
+
 
 class BrowserLauncher:
 
@@ -58,13 +60,16 @@ class BrowserLauncher:
         #     proxy.ssl_proxy = proxy_string
         #     proxy.add_to_capabilities(caps)
 
+        options = ChromeOptions()
+
         from arjuna import log_debug
         log_debug("Is proxy set for Chrome?: {}".format(proxy is not None))
         if proxy is not None:
-            proxy.add_to_capabilities(caps)
+            options.add_argument('--proxy-server=%s' % "{}:{}".format(C("http.proxy.host"), C("http.proxy.port")))
+            # proxy.add_to_capabilities(caps)
             caps['acceptInsecureCerts'] = True
 
-        options = ChromeOptions()
+        
 
         if browser_bin_path.lower() != "not_set":
             options.binary_location = browser_bin_path
@@ -83,17 +88,18 @@ class BrowserLauncher:
             for ext in config["browserExtensions"]:
                 options.add_extension(ext)
 
-        caps[ChromeOptions.KEY] = options.to_capabilities()[ChromeOptions.KEY]
+        # caps[ChromeOptions.KEY] = options.to_capabilities()[ChromeOptions.KEY]
         from selenium import webdriver
-        return webdriver.Remote(svc_url, caps)
+
+        return webdriver.Remote(svc_url, options=options)
 
     @classmethod
     def _create_firefox(cls, config, driver_path, browser_bin_path, svc_url, proxy=None):
         from selenium.webdriver import Firefox
         from selenium.webdriver import FirefoxOptions
-        from selenium.webdriver import FirefoxProfile
+        # from selenium.webdriver import FirefoxProfile
 
-        profile = FirefoxProfile()
+        # profile = FirefoxProfile()
         # if config["arjuna_options"]["BROWSER_PROXY_ON"]:
         #     proxy = Proxy()
         #     proxy_string = "{}.{}".format(
@@ -107,13 +113,14 @@ class BrowserLauncher:
         caps = DesiredCapabilities.FIREFOX
         caps.update(config["driverCapabilities"])
 
-        from arjuna import log_debug
+        options = FirefoxOptions()
+
         log_debug("Is proxy set for Firefox?: {}".format(proxy is not None))
         if proxy is not None:
-            proxy.add_to_capabilities(caps)
+            options.set_preference('network.proxy.type', 1)
+            options.set_preference('network.proxy.http', C("http.proxy.host"))
+            options.set_preference('network.proxy.http_port', C("http.proxy.port"))    
             caps['acceptInsecureCerts'] = True
-
-        options = FirefoxOptions()
 
         if browser_bin_path.lower() != "not_set":
             options.binary_location = browser_bin_path
@@ -130,7 +137,7 @@ class BrowserLauncher:
                 options.add_argument(arg)
 
         from selenium import webdriver
-        return webdriver.Remote(svc_url, browser_profile=profile, options=options)
+        return webdriver.Remote(svc_url, options=options)
 
         # driver = Firefox(executable_path=driver_path, firefox_profile=profile, capabilities=caps)
         # if cls.are_extensions_set(config):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name = "arjuna",
-    version = "1.2.25",
+    version = "1.2.26",
     url = "https://rahulverma.net",
     description = "Arjuna is a Python based test automation framework developed by Rahul Verma (www.rahulverma.net).",
     author = "Rahul Verma",
@@ -57,12 +57,12 @@ setup(
     },
     install_requires = [
         "pyOpenSSL>=0.14",
-        "urllib3==1.25.3",
-        "requests==2.22.0",
+        "urllib3==2.0.7",
+        "requests==2.31.0",
         "lxml==4.6.3",
-        "requests-toolbelt==0.9.1", 
-        "selenium==4.0.0a7", 
-        "webdriver_manager==3.2.2", 
+        "requests-toolbelt==1.0.0", 
+        "selenium==4.14.0", 
+        "webdriver_manager==4.0.1", 
         "xlrd==1.2.0", 
         "xlwt==1.3.0", 
         "pyparsing==2.4.0", 


### PR DESCRIPTION
Changelist:
 
1. update arjuna version from 1.2.25 to 1.2.26 in setup.py
2. update following library versions in `setup.py`
"selenium==4.14.0", 
"urllib3==2.0.7",
"requests==2.31.0",
"requests-toolbelt==1.0.0", 
"webdriver_manager==4.0.1", 
3. disable "UNEXPECTED_ALERT_BEHAVIOUR", as its removed as part of W3C implementation and "UNHANDLED_PROMPT_BEHAVIOUR" is the solution
4. set proxy using `options` instead of `capabilities` (due to selenium library upgrade)
5. no explicit changes, but latest webdriver-manager solves new chrome-manager issue with > **115v**, where new download mechanism/URL introduced with "Chrome for testing".
